### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/website.render/package.json
+++ b/website.render/package.json
@@ -61,7 +61,6 @@
     "input-otp": "^1.4.2",
     "jose": "6.1.0",
     "lucide-react": "^0.453.0",
-    
     "nanoid": "^5.1.5",
     "next-themes": "^0.4.6",
     "nodemailer": "^7.0.11",
@@ -82,7 +81,8 @@
     "zod": "^4.1.12",
     "vite": "^7.1.11",
     "esbuild": "^0.25.0",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",
@@ -116,4 +116,4 @@
     }
   }
 }
-
+    


### PR DESCRIPTION
Potential fix for [https://github.com/contactscalebreakers-dev/website.render/security/code-scanning/5](https://github.com/contactscalebreakers-dev/website.render/security/code-scanning/5)

The best way to fix this vulnerability is to introduce a rate limiting middleware, such as `express-rate-limit`, and apply it to the vulnerable route. This will prevent excessive requests from overwhelming the server or the file system.

- Add the required import for `express-rate-limit`.
- Create a limiter instance, e.g. with max 100 requests per 15 minutes (or a value suitable for your application's needs).
- Apply the limiter to the `app.use("*", ...)` route before the handler function.

Specifically, within website.render/server/_core/vite.ts:

- Add an import statement for express-rate-limit at the top.
- In the `serveStatic` function, before the `"*"` route, define and apply the limiter middleware.
- Optionally, the limiter can be instantiated outside the function if shared elsewhere, but to minimize changes, instantiate it within the function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
