### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "vaul": "^1.1.2",
     "vite": "^7.1.7",
     "wouter": "^3.3.5",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",

--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -1,6 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import { type Server } from "http";
+import rateLimit from "express-rate-limit";
 import { nanoid } from "nanoid";
 import path from "path";
 import { createServer as createViteServer } from "vite";
@@ -60,8 +61,12 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
-  // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  // apply rate limiting to the fallback route that serves index.html
+  const fallbackLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+  app.use("*", fallbackLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/contactscalebreakers-dev/website.render/security/code-scanning/3](https://github.com/contactscalebreakers-dev/website.render/security/code-scanning/3)

To address the problem, add a rate limiting middleware to the fallback route handler in `serveStatic`, or preferably, apply it globally to all routes if appropriate. This can be done using the well-known package `express-rate-limit`. The fix involves:

- Installing `express-rate-limit` if it isn't present.
- Importing `express-rate-limit` at the top.
- Creating a basic rate limiter (e.g., 100 requests per 15 minutes).
- Applying the limiter to the fallback `"*"` route inside `serveStatic`.
- Only the regions of code relevant to the fallback handler in `serveStatic` will be edited, plus a new import statement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
