### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/website.render/server/_core/vite.ts
+++ b/website.render/server/_core/vite.ts
@@ -22,7 +22,12 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
-  app.use("*", async (req, res, next) => {
+  // Apply rate limiting for the dev HTML handler
+  const viteDevLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+  app.use("*", viteDevLimiter, async (req, res, next) => {
     const url = req.originalUrl;
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/contactscalebreakers-dev/website.render/security/code-scanning/4](https://github.com/contactscalebreakers-dev/website.render/security/code-scanning/4)

To fix the problem, we should apply rate limiting middleware to the relevant HTTP handler so that repeated requests, especially those that would trigger a file system read, are constrained. The most targeted, robust fix is to use `express-rate-limit` to wrap the expensive route inside `setupVite`.   

We can do this by initializing a rate limiter instance (e.g., limit to 100 requests per 15 min per IP) and applying it as middleware right before the handler in the `app.use("*", ...)` definition in `setupVite`. This matches the defensive pattern already used in the `serveStatic` method.

**Specific changes:**
- In the `setupVite` function (line 10+), define a rate limiter middleware (using `rateLimit` which is already imported).
- Apply that limiter directly before the handler on line 25, e.g. `app.use("*", viteDevLimiter, async (req, res, next) => ... )`.

No new imports or dependencies are needed, as `express-rate-limit` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
